### PR TITLE
Downgrade compatibility version to JVM 11

### DIFF
--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -35,9 +36,15 @@ kotlin {
     }
 }
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        allWarningsAsErrors = true
+    compilerOptions {
+        allWarningsAsErrors.set(true)
+        jvmTarget.set(JVM_11)
     }
 }
 


### PR DESCRIPTION
This will ensure better compatibility with lower JVM version like Android.