### PR TITLE
Enable K2 and add new Kotlin IC flags

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,6 +43,7 @@ tasks.withType<KotlinCompile> {
     compilerOptions {
         allWarningsAsErrors.set(true)
         jvmTarget.set(JVM_11)
+        freeCompilerArgs.add("-Xsuppress-version-warnings")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,9 @@ org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 # Forced increase of Metaspace
 # https://github.com/gradle/gradle/issues/23698
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g
+
+kotlin.experimental.tryK2=true
+# New Kotlin IC flags
+kotlin.compiler.suppressExperimentalICOptimizationsWarning=true
+kotlin.compiler.keepIncrementalCompilationCachesInMemory=true
+kotlin.compiler.preciseCompilationResultsBackup=true

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -48,6 +48,7 @@ tasks.withType<KotlinCompile> {
     compilerOptions {
         allWarningsAsErrors.set(true)
         jvmTarget.set(JVM_11)
+        freeCompilerArgs.add("-Xsuppress-version-warnings")
     }
 }
 

--- a/processor/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationKt.kt
+++ b/processor/src/test/kotlin/com/tschuchort/compiletesting/KotlinCompilationKt.kt
@@ -27,5 +27,7 @@ fun compile(
     symbolProcessorProviders = listOf(SealedObjectInstancesProcessorProvider())
     kspWithCompilation = true
     inheritClassPath = true
+    supportsK2 = true
+    kotlincArguments += listOf("-Xskip-prerelease-check", "-Xallow-unstable-dependencies")
     configure()
 }.compile()


### PR DESCRIPTION
Configure `allWarningsAsErrors` to follow `kotlin.experimental.tryK2` property

`w: Language version 2.0 is experimental, there are no backwards compatibility guarantees for new language and library features`