### PR TITLE
Bump com.gradleup.nmcp from 0.2.1 to 1.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,5 +18,5 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
 jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-nmcp = "com.gradleup.nmcp:0.2.1"
+nmcp = "com.gradleup.nmcp:1.0.0"
 spotless = "com.diffplug.spotless:7.0.4"


### PR DESCRIPTION
@dependabot is currently broken...

https://github.com/dependabot/dependabot-core/issues/12558