### PR TITLE
🐘 Enable `org.gradle.tooling.parallel`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,4 @@ kotlin.code.style=official
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
Add `org.gradle.tooling.parallel=true` to enable parallel tooling daemon processes for faster builds.